### PR TITLE
Fix runtime error

### DIFF
--- a/HTTPUpload.swift
+++ b/HTTPUpload.swift
@@ -29,7 +29,7 @@ public class HTTPUpload: NSObject, NSCoding {
     /// Tries to determine the mime type from the fileUrl extension.
     func updateMimeType() {
         if mimeType == nil && fileUrl != nil {
-            let pathExtension = fileUrl?.pathExtension as! CFString
+            let pathExtension = fileUrl!.pathExtension! as CFString
             let UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension, nil);
             let str = UTTypeCopyPreferredTagWithClass(UTI!.takeUnretainedValue(), kUTTagClassMIMEType);
             if (str == nil) {


### PR DESCRIPTION
Despite the casting being syntactically valid, there is a runtime error during the execution

```
swift thread 1: exc_bad_instruction(code=exc_i386_invop,subcode=0x0) error
```

After the change it works fine.
